### PR TITLE
レイアウト修正

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,7 @@
+.overflow-hidden {
+  overflow: hidden;
+}
+
 .mapContainer {
   width: 100%;
   height: 70vh;

--- a/src/App.js
+++ b/src/App.js
@@ -79,7 +79,7 @@ class App extends Component {
 
   render(){
     return (
-      <div>
+      <div className="overflow-hidden">
         <Router>
           <ul>
             <li>


### PR DESCRIPTION
## WHY
- 地図が大きすぎる
- 横に余白があり, 左右にスクロールできてしまう

## WHAT
- `overflow: hidden` を指定して余白を削除
- 地図の height を調整

<img width="374" alt="スクリーンショット 2021-04-23 17 19 35" src="https://user-images.githubusercontent.com/18570970/115842000-5a0fe300-a458-11eb-84c3-b3283ed3a761.png">
