### PR TITLE
MapBoxのコンフリクト解消時に生まれたバグの修正

### DIFF
--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -28,7 +28,7 @@ export default class MapBox extends Component {
     }
     this.history = []
     this.previous_location = undefined
-    this.min_duration = 2000
+    this.min_duration = 2000 //ms
     //watchPositionの実行idを管理
     this.watch_id = -1
 


### PR DESCRIPTION
### What
昨日MapBox.jsがプルしてきたものとローカルとで差分があったので、そのコンフリクトを解消したのですが、ところどころ間違えて古いコードの方を採用していたらしく、エラーが起きていました。コードを修正し、以下のことについて動作確認しています。
- ページロード時に現在位置がマップの中心にきているか
- ログのレコードが正常に行えるか
- ページ遷移があっても（リロードせずに）正常に動作するか