### PR TITLE
地図ページ読み込み時でのDBに保存されていたトラックデータの表示

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,16 +19,38 @@ class App extends Component {
     super(props)
     this.state = {
       current_user: {
-        id: '2',
+        id: '1',
         name: 'hoge',
       },
       form: {
         name: '',
       },
+      track_id: '1'
     }
 
+    this.getCurrentUser = this.getCurrentUser.bind(this)
     this.handleProfileChange = this.handleProfileChange.bind(this)
     this.handleProfileUpdate = this.handleProfileUpdate.bind(this)
+  }
+
+  getCurrentUser() {
+    let id = this.state.current_user.id //devise導入後要修正
+    const url = RAILS_API_ENDPOINT + '/users/'+ id
+    axios
+      .get(url)
+      .then((results) => {
+          const data = results.data
+          this.setState({current_user: data})
+          //formの情報の更新(分離した方がいい？)
+          this.setState({form: {
+            name: this.state.current_user.name,
+          }
+        })
+      })
+      .catch(
+        (error) => {
+          console.log(error)
+      })
   }
 
   //formの入力内容の変更を検知
@@ -68,12 +90,7 @@ class App extends Component {
 
   componentDidMount() {
     //current_userの更新
-
-    //formの情報の更新
-    this.setState({form: {
-        name: this.state.current_user.name,
-      }
-    })
+    this.getCurrentUser();
   }
 
 
@@ -97,6 +114,7 @@ class App extends Component {
               <Header />
               <MapBox
               current_user = {this.state.current_user}
+              track_id = {this.state.track_id}
               />
               <Menu 
               current_user = {this.state.current_user}

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -155,7 +155,6 @@ export default class MapBox extends Component {
   }
 
   componentDidMount() {
-    const track_id = this.props.track_id
     navigator.geolocation.getCurrentPosition(this.setMap)
   }
 


### PR DESCRIPTION
### WHAT
- App.jsにステート：track_idを追加
- MapBox.jsに描画を実行する関数getTrackを作成、setMap関数内で呼び出し
  - リクエスト送信
  - レスポンスをうけて文字列から二次元配列へ変換し、old_historyに代入
  - 描画レイヤーの初期化、old_historyの描画（ただし現状表示されず）
- ログイン済みのユーザidを用いてステートcurrent_userの情報を更新するgetCurrentUserを作成

### WHY
- track_idの追加：複数のファイルで今後getTrackを呼び出す可能性があるため、表示したいトラックのidは最上位で管理する必要がある

### TODO
- old_historyが描画されない問題の解決
- devise導入をうけてgetCurrentUser関数を修正：idの値を、認証されたidを用いるようにする
- getTrackのリファクタリング：現在単に「トラックデータを取得する」だけでなく描画も行っているので、意味論的にgetTrackは相応しくない。getTrack自体をrenameするか、描画部分を分割して別の関数を作成する必要がある。
- getTrackのファイル分割