### PR TITLE
googlefontの適用

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap');
+
+* {
+  font-family: 'Kosugi Maru', sans-serif;
+}
+
 .overflow-hidden {
   overflow: hidden;
 }


### PR DESCRIPTION
### WHAT
- google fontの導入：kosugi maruの適用。（看板文字の丸ゴシックみたいでかわいい）（けど英字がダサいので英字フォントは別途追記）

![image](https://user-images.githubusercontent.com/47634358/118989993-781c2500-b9bd-11eb-81d6-205bceade1f0.png)
