### PR TITLE
ログイン中のユーザに紐づいたログを全件表示

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,14 +34,15 @@ class App extends Component {
   }
 
   getCurrentUser() {
-    let id = this.state.current_user.id //devise導入後要修正
+    //TODO: device導入後, state.current_user.idを現在ログイン中のidで更新する処理を追記
+    let id = this.state.current_user.id 
     const url = RAILS_API_ENDPOINT + '/users/'+ id
     axios
       .get(url)
       .then((results) => {
           const data = results.data
           this.setState({current_user: data})
-          //formの情報の更新(分離した方がいい？)
+          //formの情報の更新
           this.setState({form: {
             name: this.state.current_user.name,
           }

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -69,17 +69,15 @@ export default class MapBox extends Component {
   }
 
   getAllTrack(user_id) {
-    const url = RAILS_API_ENDPOINT + '/tracks/'
+    const url = RAILS_API_ENDPOINT + '/users_tracks/' + user_id
     axios
       .get(url)
       .then((results) => {
           let data = results.data
           let decoded_data
           for(let i = 0; i < data.length; i++) {
-            if(data[i].user_id === user_id) {
-              decoded_data = decodeTrack(data[i].data)
-              addTrackLayer(this.map, "track_"+String(i), decoded_data);
-            }
+            decoded_data = decodeTrack(data[i].data)
+            addTrackLayer(this.map, "track_"+String(i), decoded_data);
           }
           
       })

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -68,16 +68,20 @@ export default class MapBox extends Component {
     }
   }
 
-  // Get Track
-  getAllTrack(id) {
-    const url = RAILS_API_ENDPOINT + '/tracks/'+ id
+  getAllTrack(user_id) {
+    const url = RAILS_API_ENDPOINT + '/tracks/'
     axios
       .get(url)
       .then((results) => {
-          let data = results.data.data
-          const decoded_data = decodeTrack(data)
-          addTrackLayer(this.map, "all_track")
-          drawTrack(this.map, "all_track", decoded_data)
+          let data = results.data
+          let decoded_data
+          for(let i = 0; i < data.length; i++) {
+            if(data[i].user_id === user_id) {
+              decoded_data = decodeTrack(data[i].data)
+              addTrackLayer(this.map, "track_"+String(i), decoded_data);
+            }
+          }
+          
       })
       .catch(
         (error) => {
@@ -85,7 +89,23 @@ export default class MapBox extends Component {
       })
   }
 
-  // Post Track
+  // GetTrack
+  getTrack(id) {// DBからidで指定されたtrackデータを取得し,レスポンスがあればtrack_(id)という名前のソース,レイヤーを作成.
+    const url = RAILS_API_ENDPOINT + '/tracks/'+ id
+    axios
+      .get(url)
+      .then((results) => {
+          let data = results.data.data
+          const decoded_data = decodeTrack(data)
+          addTrackLayer(this.map, "track_"+String(id), decoded_data);
+      })
+      .catch(
+        (error) => {
+          console.log(error)
+      })
+  }
+
+  // PostTrack
   postTrack(data) {
     const encoded_data = encodeTrack(data)
     let body = {
@@ -144,9 +164,11 @@ export default class MapBox extends Component {
     })
     this.map.addControl(geolocate);
     this.map.on('load', function() {
-      this.getAllTrack(this.props.track_id)
+      this.getAllTrack(this.props.current_user.id)
+
       // 記録用のレイヤーの追加
       addTrackLayer(this.map, "current_track")
+      
       }.bind(this)
     )
   }

--- a/src/lib/AddTrackLayer.js
+++ b/src/lib/AddTrackLayer.js
@@ -1,4 +1,4 @@
-export default function AddTrackLayer(map, id) {
+export default function AddTrackLayer(map, id, track=[]) {
   map.addSource(id, {
     'type': 'geojson',
     'data': {
@@ -6,7 +6,7 @@ export default function AddTrackLayer(map, id) {
       'properties': {},
       'geometry': {
         'type': 'LineString',
-        'coordinates': []
+        'coordinates': track
       }
     }
   });


### PR DESCRIPTION
### WHAT
- アプリロード時にユーザごとの（current_user.idに紐づいた）トラックデータを全件表示するように変更。

![image](https://user-images.githubusercontent.com/47634358/119246883-17a90580-bbc0-11eb-9fd1-385f131f9dc7.png)
![image](https://user-images.githubusercontent.com/47634358/119246899-3c04e200-bbc0-11eb-8656-811be552f0ef.png)
![image](https://user-images.githubusercontent.com/47634358/119246907-58a11a00-bbc0-11eb-9bf2-b31058890e8b.png)

### 懸案事項
- if ( track.user_id === current_user.id )という条件式の検証のために一度全ユーザのtrackデータを取得してきている。データの件数が肥大したとき動作が不安定になるので、できれば予めそのユーザが持つtrack_idが何番なのかという情報を用意し、その情報のみリクエストする仕様に変えたい。
- 全部の情報を表示するために「複数の」レイヤーを作成しているが、今後、全件表示・全件非表示といった動作を実装することを考えるとこれは非常に扱いづらい。（すべてのレイヤーに対して表示・非表示のプロパティを叩きに行く必要がある）理想は「一つの」レイヤーにすべてのSourceが流し込まれている状態にしたい。
方針としては２つ、
①配列を予めjoinして一つの配列にする
②複数のsourceのidを一つのレイヤーに関連付ける
だが、①はできればやりたくない。後のnext / prevの実装に際して１件ずつ参照する可能性があることを考えるとjoinするのは得策ではないし、配列が１つにまとまったとき切り離されていてほしいはずの軌跡が一筆書きになってしまう（気がする）から。ということで②をやりたいけど、②の実装はみたことがないので本当にできるのか？について調査が必要。だけど、こないだ等高線のデータを表示してるサンプルがあったから、上手いことやればたぶんできる。
https://docs.mapbox.com/vector-tiles/reference/mapbox-terrain-v2/

