### PR TITLE
prev/next機能の実装

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,10 +25,13 @@ class App extends Component {
       form: {
         name: '',
       },
-      track_id: '1'
+      track_num: '0', //全Track数
+      map: '',
     }
 
     this.getCurrentUser = this.getCurrentUser.bind(this)
+    this.handleMapCreate = this.handleMapCreate.bind(this)
+    this.handleTrackNumChange = this.handleTrackNumChange.bind(this)
     this.handleProfileChange = this.handleProfileChange.bind(this)
     this.handleProfileUpdate = this.handleProfileUpdate.bind(this)
   }
@@ -52,6 +55,14 @@ class App extends Component {
         (error) => {
           console.log(error)
       })
+  }
+
+  handleMapCreate(map) {
+    this.setState({map: map});
+  }
+
+  handleTrackNumChange(num) {
+    this.setState({track_num: num});
   }
 
   //formの入力内容の変更を検知
@@ -116,10 +127,16 @@ class App extends Component {
               <MapBox
               current_user = {this.state.current_user}
               track_id = {this.state.track_id}
+              track_num = {this.state.track_num}
+              map = {this.state.map}
+              handleMapCreate = {this.handleMapCreate}
+              handleTrackNumChange = {this.handleTrackNumChange}
               />
               <Menu 
               current_user = {this.state.current_user}
               form = {this.state.form}
+              map = {this.state.map}
+              track_num = {this.state.track_num}
               handleProfileChange = {this.handleProfileChange}
               handleProfileUpdate = {this.handleProfileUpdate}
               />

--- a/src/components/menu/App.js
+++ b/src/components/menu/App.js
@@ -3,7 +3,6 @@ import ProfileContent from './content/Profile';
 import TracksContent from './content/Tracks';
 import SettingContent from './content/Setting';
 import Navigation from './nav/Navigation';
-import hideAllTracks from '../../lib/HideAllTracks'
 import showAllTracks from '../../lib/ShowAllTracks'
 
 export default class App extends Component {
@@ -23,9 +22,7 @@ export default class App extends Component {
                       let map = this.props.map
                       let track_num = this.props.track_num
 
-                      if(this.state.value === 'Tracks') {
-                        // hideAllTracks(map, track_num)
-                      } else {
+                      if(this.state.value !== 'Tracks') {
                         showAllTracks(map, track_num)
                       }
                     });

--- a/src/components/menu/App.js
+++ b/src/components/menu/App.js
@@ -3,6 +3,8 @@ import ProfileContent from './content/Profile';
 import TracksContent from './content/Tracks';
 import SettingContent from './content/Setting';
 import Navigation from './nav/Navigation';
+import hideAllTracks from '../../lib/HideAllTracks'
+import showAllTracks from '../../lib/ShowAllTracks'
 
 export default class App extends Component {
   constructor(props){
@@ -16,7 +18,18 @@ export default class App extends Component {
   render() {
     const { value } = this.state; //これ{}無いと動かん理由わからん
     const handleNavChange = (e, value) => {
-      this.setState({ value });
+      this.setState({ value },
+                    () => {
+                      let map = this.props.map
+                      let track_num = this.props.track_num
+
+                      if(this.state.value === 'Tracks') {
+                        // hideAllTracks(map, track_num)
+                      } else {
+                        showAllTracks(map, track_num)
+                      }
+                    });
+      
     };
     const handleProfileChange = this.props.handleProfileChange
     const handleProfileUpdate = this.props.handleProfileUpdate
@@ -25,13 +38,15 @@ export default class App extends Component {
     console.log(this.props)
     return(
       <div>
-        <Navigation value={ value } handleChange = { handleNavChange }/>
+        <Navigation value={ value } handleNavChange = { handleNavChange }/>
 
         {this.state.value === 'Profile' ? 
          <ProfileContent current_user = { current_user } />
          : 
          this.state.value === 'Tracks' ?
-         <TracksContent></TracksContent> 
+         <TracksContent
+         map = {this.props.map}
+         track_num = {this.props.track_num} /> 
          :
          this.state.value === 'Setting' ?
          <SettingContent

--- a/src/components/menu/content/Tracks.js
+++ b/src/components/menu/content/Tracks.js
@@ -50,6 +50,19 @@ class Track extends Component {
   render() {
       //参考： https://stackoverflow.com/questions/56554586/how-to-use-usestyle-to-style-class-component-in-material-ui
       const { classes } = this.props;
+      const handlePrevTrack = () => {
+        hideTrackLayer(this.props.map, 'track_'+this.state.track_id)
+        this.setState({
+          track_id: (this.state.track_id - 1 + this.props.track_num) % this.props.track_num
+        }, () => {showTrackLayer(this.props.map, 'track_'+this.state.track_id)})
+      }
+      const handleNextTrack = () => {
+        hideTrackLayer(this.props.map, 'track_'+this.state.track_id)
+        this.setState({
+          track_id: (this.state.track_id + 1 + this.props.track_num) % this.props.track_num
+        }, () => {showTrackLayer(this.props.map, 'track_'+this.state.track_id)})
+      }
+      
     return(
 
       <div>
@@ -101,14 +114,7 @@ class Track extends Component {
               variant="outlined"
               color="primary"
               fullWidth={true}
-              onClick = {
-                () => {
-                  hideTrackLayer(this.props.map, 'track_'+this.state.track_id)
-                  this.setState({
-                    track_id: (this.state.track_id - 1 + this.props.track_num) % this.props.track_num
-                  }, () => {showTrackLayer(this.props.map, 'track_'+this.state.track_id)})
-                }
-              }
+              onClick = { handlePrevTrack }
             >
               prev
             </Button>
@@ -119,14 +125,7 @@ class Track extends Component {
               variant="outlined"
               color="primary"
               fullWidth={true}
-              onClick = {
-                () => {
-                  hideTrackLayer(this.props.map, 'track_'+this.state.track_id)
-                  this.setState({
-                    track_id: (this.state.track_id + 1 + this.props.track_num) % this.props.track_num
-                  }, () => {showTrackLayer(this.props.map, 'track_'+this.state.track_id)})
-                }
-              }
+              onClick = { handleNextTrack }
             >
               next
             </Button>

--- a/src/components/menu/content/Tracks.js
+++ b/src/components/menu/content/Tracks.js
@@ -13,10 +13,14 @@ import {
 
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import ShareIcon from '@material-ui/icons/Share';
-import { makeStyles } from '@material-ui/core/styles';
+import { withStyles } from "@material-ui/core/styles";
 
+// import handleCurrentTrack from '../../../lib/HandleCurrentTrack'; //TODO: handleCurrentTrackを使用した実装に変更
+import showTrackLayer from '../../../lib/ShowTrackLayer';
+import hideTrackLayer from '../../../lib/HideTrackLayer';
+import hideAllTracks from '../../../lib/HideAllTracks';
 
-const useStyles = makeStyles({
+const styles = theme => ({
   root: {
     maxWidth: 360,
   },
@@ -28,71 +32,116 @@ const useStyles = makeStyles({
   }
 });
 
-export default function Tracks() {
-  const classes=useStyles();
-  return(
-    <div>
-      <Grid container 
-        spacing={2}
-        alignItems="center"
-        justify="center"
-        direction="column"
-      >
-        <Grid item xs={12}>
-         <Card className={classes.root}>
-            <CardContent>
-              <CardMedia
-                  className={classes.media}
-                  image={process.env.PUBLIC_URL+"/track_test.png"}
-              >
-              <div>
-                <Typography align="center" color="textSecondary" gutterBottom>
-                2021.5.1.sat
-                </Typography>
-                <Typography align="center" variant="h5" component="h2">
-                  DISTANCE 100.0km
-                </Typography>
-                <Typography align="center" variant="h5" component="h2">
-                  ALTITUDE 300m
-                </Typography>
-              </div>
-              </CardMedia> 
-            </CardContent>
+class Track extends Component {
 
-            <CardActions disableSpacing className={classes.actions}>
-              <Grid container alignItems="center" justify="center">
-                <Grid xs={0}>
-                  <IconButton aria-label="add to favorites">
-                    <FavoriteIcon />
-                      </IconButton>
-                    <IconButton aria-label="share">
-                      <ShareIcon />
-                  </IconButton>
+  constructor(props) {
+    super(props)
+    this.state = {
+      track_id : '0'//Tracksタブで表示中のtrack_id
+    }
+  }
+
+  componentDidMount() {
+    hideAllTracks(this.props.map, this.props.track_num)
+    showTrackLayer(this.props.map, 'track_'+this.state.track_id)
+    console.log('hoge')
+  }
+
+  render() {
+      //参考： https://stackoverflow.com/questions/56554586/how-to-use-usestyle-to-style-class-component-in-material-ui
+      const { classes } = this.props;
+    return(
+
+      <div>
+        <Grid container 
+          spacing={2}
+          alignItems="center"
+          justify="center"
+          direction="column"
+        >
+          <Grid item xs={12}>
+          <Card className={classes.root}>
+              <CardContent>
+                <CardMedia
+                    className={classes.media}
+                    image={process.env.PUBLIC_URL+"/track_test.png"}
+                >
+                <div>
+                  <Typography align="center" color="textSecondary" gutterBottom>
+                  2021.5.1.sat
+                  </Typography>
+                  <Typography align="center" variant="h5" component="h2">
+                    DISTANCE 100.0km
+                  </Typography>
+                  <Typography align="center" variant="h5" component="h2">
+                    ALTITUDE 300m
+                  </Typography>
+                </div>
+                </CardMedia> 
+              </CardContent>
+
+              <CardActions disableSpacing className={classes.actions}>
+                <Grid container alignItems="center" justify="center">
+                  <Grid xs={0}>
+                    <IconButton aria-label="add to favorites">
+                      <FavoriteIcon />
+                        </IconButton>
+                      <IconButton aria-label="share">
+                        <ShareIcon />
+                    </IconButton>
+                  </Grid>
                 </Grid>
-              </Grid>
-            </CardActions>
-          </Card>
+              </CardActions>
+            </Card>
+          </Grid>
         </Grid>
-      </Grid>
-      <Grid container spacing={2}>
-        <Grid item xs={6}>
-          <Button variant="outlined" color="primary" fullWidth={true}>
-            prev
-          </Button>
-        </Grid>
+        <Grid container spacing={2}>
+          <Grid item xs={6}>
+            <Button
+              variant="outlined"
+              color="primary"
+              fullWidth={true}
+              onClick = {
+                () => {
+                  hideTrackLayer(this.props.map, 'track_'+this.state.track_id)
+                  this.setState({
+                    track_id: (this.state.track_id - 1 + this.props.track_num) % this.props.track_num
+                  }, () => {showTrackLayer(this.props.map, 'track_'+this.state.track_id)})
+                }
+              }
+            >
+              prev
+            </Button>
+          </Grid>
 
-        <Grid item xs={6}>
-          <Button variant="outlined" color="primary" fullWidth={true}>
-            next
-          </Button>
-        </Grid>
+          <Grid item xs={6}>
+          <Button
+              variant="outlined"
+              color="primary"
+              fullWidth={true}
+              onClick = {
+                () => {
+                  hideTrackLayer(this.props.map, 'track_'+this.state.track_id)
+                  this.setState({
+                    track_id: (this.state.track_id + 1 + this.props.track_num) % this.props.track_num
+                  }, () => {showTrackLayer(this.props.map, 'track_'+this.state.track_id)})
+                }
+              }
+            >
+              next
+            </Button>
+          </Grid>
 
-        <Grid item xs={12}>
-          <Button variant="outlined" color="secondary" fullWidth={true}>
-            delete
-          </Button>
+          <Grid item xs={12}>
+            <Button variant="outlined" color="secondary" fullWidth={true}>
+              delete
+            </Button>
+          </Grid>
         </Grid>
-      </Grid>
-    </div>
-  )
+      </div>
+    )
+  }
+
 }
+
+export default withStyles(styles, { withTheme: true })(Track);

--- a/src/components/menu/content/Tracks.js
+++ b/src/components/menu/content/Tracks.js
@@ -13,7 +13,7 @@ import {
 
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import ShareIcon from '@material-ui/icons/Share';
-import { withStyles } from "@material-ui/core/styles";
+import { withStyles } from '@material-ui/core/styles';
 
 // import handleCurrentTrack from '../../../lib/HandleCurrentTrack'; //TODO: handleCurrentTrackを使用した実装に変更
 import showTrackLayer from '../../../lib/ShowTrackLayer';

--- a/src/components/menu/nav/Navigation.js
+++ b/src/components/menu/nav/Navigation.js
@@ -11,7 +11,7 @@ import SettingsIcon from '@material-ui/icons/Settings';
 export default class Navigation extends Component {
     render() {
         return(
-            <BottomNavigation value={ this.props.value } onChange={ this.props.handleChange }>
+            <BottomNavigation value={ this.props.value } onChange={ this.props.handleNavChange }>
             <BottomNavigationAction label="Profile" value="Profile" icon={<PersonIcon />} />
             <BottomNavigationAction label="Tracks" value="Tracks" icon={<TimelineIcon />} />
             <BottomNavigationAction label="Setting" value="Setting" icon={<SettingsIcon />} />

--- a/src/lib/AddTrackLayer.js
+++ b/src/lib/AddTrackLayer.js
@@ -16,11 +16,11 @@ export default function AddTrackLayer(map, id, track=[]) {
     'source': id,
     'layout': {
       'line-join': 'round',
-      'line-cap': 'round'
+      'line-cap': 'round' ,
     },
     'paint': {
       'line-color': '#888',
-      'line-width': 8
+      'line-width': 8,
     }
   });
 }

--- a/src/lib/HandleCurrentTrack.js
+++ b/src/lib/HandleCurrentTrack.js
@@ -1,0 +1,10 @@
+export default function HandleCurrentTrack(map, id) { //指定されたidに対応するsourceからgeojson形式のdataを取得して、'current_track'レイヤーにデータを投げる関数
+
+    try { //addSourceが非同期のため、addSourceの実行より先にgetSourceが呼ばれてしまうことがある。
+        let src = map.getSource('track_'+id)
+        console.log(src)
+        //TODO: srcからgeojsonのみ取り出す
+      } catch(e) {
+        console.log(e)
+      }
+}

--- a/src/lib/HideAllTracks.js
+++ b/src/lib/HideAllTracks.js
@@ -1,0 +1,7 @@
+import hideTrackLayer from "./HideTrackLayer";
+
+export default function HideAllTracks(map, track_num) {
+    for (let i = 0; i < track_num; i++) {
+        hideTrackLayer(map, "track_"+String(i));
+    }
+}

--- a/src/lib/HideTrackLayer.js
+++ b/src/lib/HideTrackLayer.js
@@ -1,0 +1,8 @@
+export default function HideTrackLayer(map, id) {
+
+    map.setLayoutProperty(
+            id,
+            'visibility',
+            'none'
+        );
+}

--- a/src/lib/ShowAllTracks.js
+++ b/src/lib/ShowAllTracks.js
@@ -1,0 +1,8 @@
+import showTrackLayer from "./ShowTrackLayer";
+
+export default function HideAllTracks(map, track_num) {
+
+    for (let i = 0; i < track_num; i++) {
+        showTrackLayer(map, "track_"+String(i));
+    }
+}

--- a/src/lib/ShowTrackLayer.js
+++ b/src/lib/ShowTrackLayer.js
@@ -1,0 +1,8 @@
+export default function ShowTrackLayer(map, id) {
+
+    map.setLayoutProperty(
+            id,
+            'visibility',
+            'visible'
+        );
+}


### PR DESCRIPTION
### WHAT
- mapのstate管理（理由：以前はmapbox.jsに縛られていたためmapに関連した関数をmapbox.js外で呼び出すことはできなかったが、今回Track.jsなど他の場所でも使う必要がでてきたので、App.jsにリフトアップ。）
- track_num：track数全件のstate管理（理由：こちらもTrack.jsなど他のファイルにおいて全件非表示・全件表示などを行う必要があったため。）
- hideAllTracks, showAllTracks, hideTrackLayer, showTrackLayerの追加（それぞれ指定されたレイヤーの表示・非表示ならびにレイヤーの全件表示・非表示を管理。）

![image](https://user-images.githubusercontent.com/47634358/120070841-6296b180-c0c7-11eb-8482-8f68e6e793a0.png)
![image](https://user-images.githubusercontent.com/47634358/120070848-6f1b0a00-c0c7-11eb-8fb6-fce22cc9e407.png)
![image](https://user-images.githubusercontent.com/47634358/120070862-81954380-c0c7-11eb-8724-2813df569117.png)


### TODO
- next, prevの際にmapの位置・スケールがtrackを収めるように変化する処理の実装
- mapbox.jsから変数mapをリフトアップしたことで動かせる関数をlibに移行