### PR TITLE
マップのカラーとスケールを変更

### DIFF
--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -162,8 +162,9 @@ export default class MapBox extends Component {
     let map = new mapboxgl.Map({
       container: this.mapContainer,
       center: [this.state.current_pos.lng, this.state.current_pos.lat],
-      style: 'mapbox://styles/mapbox/streets-v9', // mapのスタイル指定
-      zoom: 16
+      style: 'mapbox://styles/mapbox/dark-v9', // mapのスタイル指定
+      zoom: 12
+      
     })
 
     this.props.handleMapCreate(map)

--- a/src/lib/AddTrackLayer.js
+++ b/src/lib/AddTrackLayer.js
@@ -19,8 +19,8 @@ export default function AddTrackLayer(map, id, track=[]) {
       'line-cap': 'round' ,
     },
     'paint': {
-      'line-color': '#888',
-      'line-width': 8,
+      'line-color': '#E7211A',
+      'line-width': 2,
     }
   });
 }


### PR DESCRIPTION
マップのカラーをダークトーンに、マップの初期スケールを12に変更。デザイン調整のため。