### PR TITLE
next/prevを押した際にマップの中心が変化

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,12 +26,13 @@ class App extends Component {
         name: '',
       },
       track_num: '0', //全Track数
+      tracks: '',
       map: '',
     }
 
     this.getCurrentUser = this.getCurrentUser.bind(this)
     this.handleMapCreate = this.handleMapCreate.bind(this)
-    this.handleTrackNumChange = this.handleTrackNumChange.bind(this)
+    this.handleTracksChange = this.handleTracksChange.bind(this)
     this.handleProfileChange = this.handleProfileChange.bind(this)
     this.handleProfileUpdate = this.handleProfileUpdate.bind(this)
   }
@@ -61,8 +62,11 @@ class App extends Component {
     this.setState({map: map});
   }
 
-  handleTrackNumChange(num) {
-    this.setState({track_num: num});
+  handleTracksChange(tracks) {
+    this.setState({
+      tracks: tracks,
+      track_num: tracks.length,
+    });
   }
 
   //formの入力内容の変更を検知
@@ -130,12 +134,13 @@ class App extends Component {
               track_num = {this.state.track_num}
               map = {this.state.map}
               handleMapCreate = {this.handleMapCreate}
-              handleTrackNumChange = {this.handleTrackNumChange}
+              handleTracksChange = {this.handleTracksChange}
               />
               <Menu 
               current_user = {this.state.current_user}
               form = {this.state.form}
               map = {this.state.map}
+              tracks = {this.state.tracks}
               track_num = {this.state.track_num}
               handleProfileChange = {this.handleProfileChange}
               handleProfileUpdate = {this.handleProfileUpdate}

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -75,32 +75,14 @@ export default class MapBox extends Component {
       .then((results) => {
           let data = results.data
           let decoded_data
-
-          this.props.handleTrackNumChange(data.length)
-
-          let track_num = this.props.track_num
+          let track_num = data.length
 
           for(let i = 0; i < track_num; i++) {
-            decoded_data = decodeTrack(data[i].data)
-            addTrackLayer(this.map, "track_"+String(i), decoded_data);
+            data[i].data = decodeTrack(data[i].data)
+            addTrackLayer(this.map, "track_"+String(i), data[i].data);
           }
-          
-      })
-      .catch(
-        (error) => {
-          console.log(error)
-      })
-  }
 
-  // GetTrack
-  getTrack(id) {// DBからidで指定されたtrackデータを取得し,レスポンスがあればtrack_(id)という名前のソース,レイヤーを作成.
-    const url = RAILS_API_ENDPOINT + '/tracks/'+ id
-    axios
-      .get(url)
-      .then((results) => {
-          let data = results.data.data
-          const decoded_data = decodeTrack(data)
-          addTrackLayer(this.map, "track_"+String(id), decoded_data);
+          this.props.handleTracksChange(data)
       })
       .catch(
         (error) => {

--- a/src/components/menu/App.js
+++ b/src/components/menu/App.js
@@ -43,6 +43,7 @@ export default class App extends Component {
          this.state.value === 'Tracks' ?
          <TracksContent
          map = {this.props.map}
+         tracks = {this.props.tracks}
          track_num = {this.props.track_num} /> 
          :
          this.state.value === 'Setting' ?

--- a/src/components/menu/content/Tracks.js
+++ b/src/components/menu/content/Tracks.js
@@ -45,9 +45,9 @@ class Track extends Component {
   handleTrackChange(option) {
     let new_track_id
     if(option === 'next') {
-      (this.state.track_id + 1 ) % this.props.track_num
+      new_track_id = (this.state.track_id + 1 ) % this.props.track_num
     } else if(option === 'prev') {
-      (this.state.track_id - 1 + this.props.track_num) % this.props.track_num
+      new_track_id = (this.state.track_id - 1 + this.props.track_num) % this.props.track_num
     } else {
       new_track_id = this.state.track_id
     }

--- a/src/components/menu/content/Tracks.js
+++ b/src/components/menu/content/Tracks.js
@@ -43,17 +43,17 @@ class Track extends Component {
   }
 
   handleTrackChange(option) {
-    let delta
+    let new_track_id
     if(option === 'next') {
-      delta = 1
+      (this.state.track_id + 1 ) % this.props.track_num
     } else if(option === 'prev') {
-      delta = -1
+      (this.state.track_id - 1 + this.props.track_num) % this.props.track_num
     } else {
-      delta = 0
+      new_track_id = this.state.track_id
     }
     
     this.setState({
-      track_id: (this.state.track_id + delta + this.props.track_num) % this.props.track_num
+      track_id: new_track_id
     }, () => {
       let coordinates = this.props.tracks[this.state.track_id].data
       let bounds = coordinates.reduce(function(bounds, coord) {


### PR DESCRIPTION
### WHAT
- stateとしてトラックデータの管理
- show/hideではなくdrawTrackを用いて表示するトラックのハンドリングを行う仕様に変更
- handleNextTrack, handlePrevTrack関数をhandleTrackChange関数として統合
- 使用してないgetTrack関数の削除

![image](https://user-images.githubusercontent.com/47634358/121010760-c4929d80-c7d0-11eb-995c-eee4d5d17d05.png)
![image](https://user-images.githubusercontent.com/47634358/121010801-d07e5f80-c7d0-11eb-9781-96e9258003d0.png)


### WHY
- stateとしてトラックデータを管理することで、軌跡全体が入り込むようにする実装に必要なdataの取得を簡易化するため。
- ２枚のレイヤーを対象にshow, hide関数を用いるより、１枚のレイヤーに対して流し込むデータを変更するほうが動作的に軽い。それに伴いshow, hide関数を使用する必要がなくなったので記述も簡易化された。
- handleNext, handlePrevの違いはインクリメントするか、デクリメントするかの違いだったので、引数でオプション指定するだけで切り替えられるひとつの関数を作成した。また、この関数に対して引数を与えなければ、現在のtrack_idに基づいてセンタライズの動作も実現できるので、ComponentDidmountでは初期化のためにこのhandleTrackChangeを用いている。