### PR TITLE
trackjsのトラック表示に関するエラーの解消

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -121,6 +121,7 @@ class App extends Component {
             <Header />
             <MapBox
               current_user = {this.state.current_user}
+              tracks = {this.state.tracks}
               track_id = {this.state.track_id}
               track_num = {this.state.track_num}
               map = {this.state.map}

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -56,9 +56,6 @@ export default class MapBox extends Component {
       this.previous_location = position;
       this._add(position)
     } else {
-      this.distance += calcDistance(this.previous_location, position)
-      this.comptime += 1
-      console.log(this.distance)
       this.addPositionToTrack(position)
     }
     drawTrack(this.map, "current_track", this.track)
@@ -69,6 +66,9 @@ export default class MapBox extends Component {
     const elapseTime = parseInt((position.timestamp - this.previous_location.timestamp))
 
     if (elapseTime > min_duration) {
+      this.distance += calcDistance(this.previous_location, position)
+      this.comptime += 1
+      console.log(this.distance)
       this._add(position) // 経過時間が設定した制限時間をこえたらヒストリ追加
       this.previous_location = position
     } else {

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -126,6 +126,7 @@ export default class MapBox extends Component {
       if(this.track.length !== 0) {
         clearTrack(this.map, "current_track") //DISCUSS: hideTrackに置き換えてclearTrackを無くせる？
         if(this.distance > 50) {
+          alert('distance(>50): ' + this.distance )
           this.postTrack(this.track)
           addTrackLayer(this.map, this.props.track_num + 1, this.track);
         } else {

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -40,7 +40,6 @@ export default class MapBox extends Component {
     //watchPositionの実行idを管理
     this.watch_id = -1
     this.distance = 0
-    this.comptime = 0 //debug
 
     this.onPosition = this.onPosition.bind(this);
     this.onClick = this.onClick.bind(this);
@@ -67,8 +66,6 @@ export default class MapBox extends Component {
 
     if (elapseTime > min_duration) {
       this.distance += calcDistance(this.previous_location, position)
-      this.comptime += 1
-      console.log(this.distance)
       this._add(position) // 経過時間が設定した制限時間をこえたらヒストリ追加
       this.previous_location = position
     } else {
@@ -128,7 +125,7 @@ export default class MapBox extends Component {
       if(this.track.length !== 0) {
         clearTrack(this.map, "current_track") //DISCUSS: hideTrackに置き換えてclearTrackを無くせる？
         if(this.distance > 50) {
-          alert('distance(>50): ' + this.distance +'\n track_length: '+ this.track.length +'\n computed(times): '+ this.comptime)
+          alert('distance(>50): ' + this.distance)
           this.postTrack(this.track)
           addTrackLayer(this.map, this.props.track_num + 1, this.track);
         } else {

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -45,7 +45,7 @@ export default class MapBox extends Component {
   }
 
   _add(position) {
-    this.track.push([position.coords.longitude, position.coords.latiude])
+    this.track.push([position.coords.longitude, position.coords.latitude])
   }
 
   onPosition(position) {
@@ -76,15 +76,15 @@ export default class MapBox extends Component {
       .get(url)
       .then((results) => {
           let data = results.data
-          let decoded_data
           let track_num = data.length
+          let tracks = []
 
           for(let i = 0; i < track_num; i++) {
-            data[i].data = decodeTrack(data[i].data)
-            addTrackLayer(this.map, "track_"+String(i), data[i].data);
+            tracks.push(decodeTrack(data[i].data))
+            addTrackLayer(this.map, "track_"+String(i), tracks[i])
           }
 
-          this.props.handleTracksChange(data)
+          this.props.handleTracksChange(tracks)
       })
       .catch(
         (error) => {
@@ -120,14 +120,18 @@ export default class MapBox extends Component {
     if(isStarted) { 
       // Record時の処理
       if(this.track.length !== 0) {
-        clearTrack(this.map, "current_track")
+        clearTrack(this.map, "current_track") //DISCUSS: hideTrackに置き換えてclearTrackを無くせる？
         this.postTrack(this.track)
+        addTrackLayer(this.map, this.props.track_num + 1, this.track);
       }
       navigator.geolocation.clearWatch(this.watch_id);
       this.setState({isStarted: !isStarted})
+      let new_tracks = this.props.tracks
+      console.log(new_tracks)
+      new_tracks.push(this.track)
+      this.props.handleTracksChange(new_tracks)
     } else { 
       // Start時の処理
-      console.log(this.track)
       if (this.track.length === 0) {
         this.watch_id = navigator.geolocation.watchPosition(this.onPosition);
         this.setState({isStarted: !isStarted})

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -7,6 +7,7 @@ import clearTrack from '../../lib/ClearTrack';
 import decodeTrack from '../../lib/DecodeTrack';
 import encodeTrack from '../../lib/EncodeTrack';
 import RecordTrigger from './RecordTrigger';
+import calcDistance from '../../lib/CalcDistance';
 import axios from 'axios';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -38,6 +39,7 @@ export default class MapBox extends Component {
     this.previous_location = undefined
     //watchPositionの実行idを管理
     this.watch_id = -1
+    this.distance = 0
 
     this.onPosition = this.onPosition.bind(this);
     this.onClick = this.onClick.bind(this);
@@ -53,6 +55,8 @@ export default class MapBox extends Component {
       this.previous_location = position;
       this._add(position)
     } else {
+      this.distance += calcDistance(this.previous_location, position)
+      console.log(this.distance)
       this.addPositionToTrack(position)
     }
     drawTrack(this.map, "current_track", this.track)
@@ -121,8 +125,12 @@ export default class MapBox extends Component {
       // Record時の処理
       if(this.track.length !== 0) {
         clearTrack(this.map, "current_track") //DISCUSS: hideTrackに置き換えてclearTrackを無くせる？
-        this.postTrack(this.track)
-        addTrackLayer(this.map, this.props.track_num + 1, this.track);
+        if(this.distance > 50) {
+          this.postTrack(this.track)
+          addTrackLayer(this.map, this.props.track_num + 1, this.track);
+        } else {
+          console.log('not saved distance(<50): ' + this.distance )
+        }
       }
       navigator.geolocation.clearWatch(this.watch_id);
       this.setState({isStarted: !isStarted})

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -40,6 +40,7 @@ export default class MapBox extends Component {
     //watchPositionの実行idを管理
     this.watch_id = -1
     this.distance = 0
+    this.comptime = 0 //debug
 
     this.onPosition = this.onPosition.bind(this);
     this.onClick = this.onClick.bind(this);
@@ -56,6 +57,7 @@ export default class MapBox extends Component {
       this._add(position)
     } else {
       this.distance += calcDistance(this.previous_location, position)
+      this.comptime += 1
       console.log(this.distance)
       this.addPositionToTrack(position)
     }
@@ -126,7 +128,7 @@ export default class MapBox extends Component {
       if(this.track.length !== 0) {
         clearTrack(this.map, "current_track") //DISCUSS: hideTrackに置き換えてclearTrackを無くせる？
         if(this.distance > 50) {
-          alert('distance(>50): ' + this.distance )
+          alert('distance(>50): ' + this.distance +'\n track_length: '+ this.track.length +'\n computed(times): '+ this.comptime)
           this.postTrack(this.track)
           addTrackLayer(this.map, this.props.track_num + 1, this.track);
         } else {

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -129,7 +129,7 @@ export default class MapBox extends Component {
           this.postTrack(this.track)
           addTrackLayer(this.map, this.props.track_num + 1, this.track);
         } else {
-          console.log('not saved distance(<50): ' + this.distance )
+          alert('not saved distance(<50): ' + this.distance )
         }
       }
       navigator.geolocation.clearWatch(this.watch_id);

--- a/src/components/menu/content/Tracks.js
+++ b/src/components/menu/content/Tracks.js
@@ -43,32 +43,33 @@ class Track extends Component {
   }
 
   handleTrackChange(option) {
-    let new_track_id
-    if(option === 'next') {
-      new_track_id = (this.state.track_id + 1 ) % this.props.track_num
-    } else if(option === 'prev') {
-      new_track_id = (this.state.track_id - 1 + this.props.track_num) % this.props.track_num
-    } else {
-      new_track_id = this.state.track_id
+    if(this.props.track_num != 0) {
+      let new_track_id
+      if(option === 'next') {
+        new_track_id = (this.state.track_id + 1 ) % this.props.track_num
+      } else if(option === 'prev') {
+        new_track_id = (this.state.track_id - 1 + this.props.track_num) % this.props.track_num
+      } else {
+        new_track_id = this.state.track_id
+      }
+      
+      this.setState({
+        track_id: new_track_id
+      }, () => {
+        let coordinates = this.props.tracks[this.state.track_id]
+        let bounds = coordinates.reduce(function(bounds, coord) {
+          return bounds.extend(coord);
+          }, new mapboxgl.LngLatBounds(coordinates[0], coordinates[0]));
+            
+          this.props.map.fitBounds(bounds, {
+          padding: 20
+          });
+        drawTrack(this.props.map, 'single_track', coordinates);
+      })
     }
-    
-    this.setState({
-      track_id: new_track_id
-    }, () => {
-      let coordinates = this.props.tracks[this.state.track_id].data
-      let bounds = coordinates.reduce(function(bounds, coord) {
-        return bounds.extend(coord);
-        }, new mapboxgl.LngLatBounds(coordinates[0], coordinates[0]));
-          
-        this.props.map.fitBounds(bounds, {
-        padding: 20
-        });
-      drawTrack(this.props.map, 'single_track', coordinates);
-    })
   }
 
   componentDidMount() {
-    let coordinates = this.props.tracks[this.state.track_id].data
     hideAllTracks(this.props.map, this.props.track_num)
     this.handleTrackChange()
   }

--- a/src/lib/CalcDistance.js
+++ b/src/lib/CalcDistance.js
@@ -1,0 +1,13 @@
+export default function CalcDistance(pos_prev, pos_current) {
+    const pi = Math.PI
+    const lng_p = pos_prev.coords.longitude
+    const lat_p = pos_prev.coords.latitude
+    const lng_c = pos_current.coords.longitude
+    const lat_c = pos_current.coords.latitude
+
+    /*地球を半径6371kmの球体と仮定. 距離[m]=6371[km]*(２地点のなす角[rad])*1000 */
+    return 6371 * Math.acos(
+        Math.cos(lat_c/180*pi) * Math.cos((lng_p - lng_c)/180*pi) * Math.cos(lat_p/180*pi) +
+        Math.sin(lat_c/180*pi) * Math.sin(lat_p/180*pi)
+      ) * 1000;
+}


### PR DESCRIPTION
### WHAT
- stateとしてのtrack管理の見直し：trackのlng, lat情報のみ保存.
- track_numが0の場合（setStateが実行される前）はhandleTrackChangeを実行しない
- 新しく取ったログデータを新規トラックレイヤーに入れて表示
- 移動距離計算の実装
- 移動距離が50m未満の場合軌跡を保存しない

### WHY
- stateとしてのtrackはいまのところ軌跡描画にしか使ってないから、全データ保持する必要がない
- track_numが0の場合, stateはundefinedの状態になっているため、このままhandleTrackを実行すると動作停止する
- トラックが１座標のみの場合, ログの表示の際バグが生じる。実用的なことを考えてトラックの長さが50m未満の場合は保存しないように変更。
