### PR TITLE
[FIX]menu.js の記法とtrack.js における prev の振る舞いを修正

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,7 +25,7 @@ class App extends Component {
       form: {
         name: "",
       },
-      track_num: 0, //全Track数
+      track_num: "0", //全Track数
       tracks: [],
       map: "",
     };
@@ -113,10 +113,10 @@ class App extends Component {
               handleState={this.handleState}
             />
             <Menu
-              currentUser={this.state.current_user}
+              current_user={this.state.current_user}
               map={this.state.map}
               tracks={this.state.tracks}
-              trackNum={this.state.track_num}
+              track_num={this.state.track_num}
             />
           </div>
         )}

--- a/src/App.js
+++ b/src/App.js
@@ -25,7 +25,7 @@ class App extends Component {
       form: {
         name: "",
       },
-      track_num: "0", //全Track数
+      track_num: 0, //全Track数
       tracks: [],
       map: "",
     };
@@ -113,11 +113,10 @@ class App extends Component {
               handleState={this.handleState}
             />
             <Menu
-              current_user={this.state.current_user}
-              form={this.state.form}
+              currentUser={this.state.current_user}
               map={this.state.map}
               tracks={this.state.tracks}
-              track_num={this.state.track_num}
+              trackNum={this.state.track_num}
             />
           </div>
         )}

--- a/src/components/menu/content/Tracks.js
+++ b/src/components/menu/content/Tracks.js
@@ -34,12 +34,18 @@ export const Tracks = ({ trackNum, tracks, map }) => {
   }, [trackID]);
 
   const changeSelectedTrack = (trackID, trackNum, tracks, map) => {
+    console.log(trackID);
     if (trackID >= 0 && trackID < trackNum) {
       let selectedCoords = tracks[trackID];
       changeMapBound(selectedCoords, map);
     } else if (trackID < 0) {
-      let selectedCoords = tracks[trackNum + (trackID % trackNum)];
-      changeMapBound(selectedCoords, map);
+      if (trackID % trackNum === 0) {
+        let selectedCoords = tracks[trackID % trackNum];
+        changeMapBound(selectedCoords, map);
+      } else {
+        let selectedCoords = tracks[trackNum + (trackID % trackNum)];
+        changeMapBound(selectedCoords, map);
+      }
     } else if (trackNum <= trackID) {
       let selectedCoords = tracks[trackID % trackNum];
       changeMapBound(selectedCoords, map);

--- a/src/components/menu/content/Tracks.js
+++ b/src/components/menu/content/Tracks.js
@@ -27,24 +27,17 @@ const styles = (theme) => ({
 export const Tracks = ({ trackNum, tracks, map }) => {
   const [trackID, setTrackID] = useState(0);
 
-  // NOTE: trackID に変更があった際に以下の関数が動作する
-  // TODO: hideAllTracks を複数呼び出しを削除
   useEffect(() => {
     changeSelectedTrack(trackID, trackNum, tracks, map);
   }, [trackID]);
-
   const changeSelectedTrack = (trackID, trackNum, tracks, map) => {
     if (trackID >= 0 && trackID < trackNum) {
       let selectedCoords = tracks[trackID];
       changeMapBound(selectedCoords, map);
     } else if (trackID < 0) {
-      if (trackID % trackNum === 0) {
-        let selectedCoords = tracks[trackID % trackNum];
-        changeMapBound(selectedCoords, map);
-      } else {
-        let selectedCoords = tracks[trackNum + (trackID % trackNum)];
-        changeMapBound(selectedCoords, map);
-      }
+      // NOTE: trackID が trackNum の倍数の場合でも期待の値を取得できる
+      let selectedCoords = tracks[(trackNum + (trackID % trackNum)) % trackNum];
+      changeMapBound(selectedCoords, map);
     } else if (trackNum <= trackID) {
       let selectedCoords = tracks[trackID % trackNum];
       changeMapBound(selectedCoords, map);

--- a/src/components/menu/content/Tracks.js
+++ b/src/components/menu/content/Tracks.js
@@ -34,7 +34,6 @@ export const Tracks = ({ trackNum, tracks, map }) => {
   }, [trackID]);
 
   const changeSelectedTrack = (trackID, trackNum, tracks, map) => {
-    console.log(trackID);
     if (trackID >= 0 && trackID < trackNum) {
       let selectedCoords = tracks[trackID];
       changeMapBound(selectedCoords, map);

--- a/src/menu.js
+++ b/src/menu.js
@@ -14,7 +14,7 @@ const styles = (theme) => ({
   },
 });
 
-export const Menu = (currentUser, form, map, tracks, trackNum) => {
+export const Menu = ({ currentUser, map, tracks, trackNum }) => {
   const [selectedAct, setSelcetedAct] = useState("");
 
   useEffect(() => {
@@ -22,7 +22,6 @@ export const Menu = (currentUser, form, map, tracks, trackNum) => {
   }, [selectedAct]);
 
   function handleActChange(value) {
-    console.log(value);
     setSelcetedAct(value);
   }
 


### PR DESCRIPTION
## WHY
- 本番において tracks の next を押しても動作しない, prev を押すとクラッシュするという事象が発生していた
- menu.js が app.js から state を受け取れていなかった

## WHAT
- functional component の 引数受け取り部分を`(...)`から`({...})`に変更
- prev 機能において `trackID` が `trackNum` の倍数の場合クラッシュしていたので その場合のみ別の分岐を追加