### PR TITLE
Navigation.jsでの引数をpropsから明記する形に変更

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { Header } from "./header";
 import { Menu } from "./menu";
 import { MapBox } from "./components/map/MapBox";
 import { UserForm } from "./components/user/App";
+import "./App.css";
 
 const styles = {
   root: {

--- a/src/components/menu/nav/Navigation.js
+++ b/src/components/menu/nav/Navigation.js
@@ -11,16 +11,12 @@ const styles = {
 };
 
 export const Navigation = ({selectedAct, setSelectedAct}) => {
-  const handleActChange = (value) => {
-    //NOTE:  we invoke the callback with the new value
-    setSelectedAct(value);
-  }
   return (
     <BottomNavigation
       style={styles.root}
       value={selectedAct}
       onChange={(e, value) => {
-        handleActChange(value);
+        setSelectedAct(value);
       }}
     >
       <BottomNavigationAction

--- a/src/components/menu/nav/Navigation.js
+++ b/src/components/menu/nav/Navigation.js
@@ -3,24 +3,22 @@ import { BottomNavigation, BottomNavigationAction } from "@material-ui/core";
 import PersonIcon from "@material-ui/icons/Person";
 import TimelineIcon from "@material-ui/icons/Timeline";
 import SettingsIcon from "@material-ui/icons/Settings";
-import { makeStyles } from "@material-ui/core/styles";
 
-const useStyles = makeStyles({
+const styles = {
   root: {
     backgroundColor: "#00a563",
   },
-});
+};
 
-export function Navigation(props) {
-  function handleActChange(value) {
+export const Navigation = ({selectedAct, setSelectedAct}) => {
+  const handleActChange = (value) => {
     //NOTE:  we invoke the callback with the new value
-    props.onChange(value);
+    setSelectedAct(value);
   }
-  const classes = useStyles();
   return (
     <BottomNavigation
-      className={classes.root}
-      value={props.value}
+      style={styles.root}
+      value={selectedAct}
       onChange={(e, value) => {
         handleActChange(value);
       }}

--- a/src/components/user/App.js
+++ b/src/components/user/App.js
@@ -1,8 +1,6 @@
 import { TextField, Button } from "@material-ui/core";
 import Grid from "@material-ui/core/Grid";
-
 import RequestAxios from "../../lib/RequestAxios";
-import "../../App.css";
 
 const styles = {
   signUpImg: {

--- a/src/menu.js
+++ b/src/menu.js
@@ -15,15 +15,11 @@ const styles = {
 };
 
 export const Menu = ({ currentUser, map, tracks, trackNum }) => {
-  const [selectedAct, setSelecetedAct] = useState();
+  const [selectedAct, setSelectedAct] = useState();
 
   useEffect(() => {
     displayMapExeceptTracks(selectedAct);
   }, [selectedAct]);
-
-  function handleActChange(value) {
-    setSelecetedAct(value);
-  }
 
   const displayMapExeceptTracks = (action) => {
     if (action === "Tracks") {
@@ -38,7 +34,7 @@ export const Menu = ({ currentUser, map, tracks, trackNum }) => {
   const isSetting = selectedAct === "Setting" ? true : false;
   return (
     <div>
-      <Navigation value={selectedAct} onChange={handleActChange} />
+      <Navigation selectedAct={selectedAct} setSelectedAct={setSelectedAct} />
       <Grid container justify="center" styles={styles.grid}>
         <Grid item xs={10}>
           {isProfile ? <Profile currentUser={currentUser} /> : null}


### PR DESCRIPTION
### WHAT
- navigation.jsの引数をpropsを用いない形に変更
- 変数名を呼び出し元のコンポーネントと統一
- stateを変更するsetSelectedAct関数をonChangeで直接呼び出す仕様に変更
- App.cssの呼び出しをsrc/App.jsのみで呼び出すように変更①

### WHY
- ① App.cssには現在全体に適用させたいコードしか記述してないので、各コンポーネントで呼び出す必要はない