### PR TITLE
リザルト画面の作成

### DIFF
--- a/src/components/result/Result.js
+++ b/src/components/result/Result.js
@@ -1,0 +1,73 @@
+import Data from "./yamanotesen.json"; //テストデータ
+import { useState, useEffect } from "react";
+import decodeTrack from "../../lib/DecodeTrack";
+import projectMercator from "../../lib/ProjectMercator";
+
+const styles = {
+  canvas: {
+    display: "block",
+    margin: "20vh auto 0",
+  },
+  text: {
+    textAlign: "center",
+    fontFamily: "Kanit",
+    color: "white",
+    position: "absolute",
+    top: "25vh",
+    left: 0,
+    right: 0,
+    margin: "auto",
+  },
+};
+
+export const Result = () => {
+  // contextを状態として持つ
+  const [context, setContext] = useState(null);
+  // 画像読み込み完了トリガー
+
+  useEffect(() => {
+    const canvas = document.getElementById("canvas");
+    canvas.width = 250;
+    canvas.height = 500;
+    const canvasContext = canvas.getContext("2d");
+    setContext(canvasContext);
+  }, []);
+
+  useEffect(() => {
+    if (context !== null) {
+      const decodedTrack = decodeTrack(Data.data);
+      const projectedTrack = projectMercator(decodedTrack, 220);
+
+      context.lineWidth = 5;
+      context.strokeStyle = "white";
+      context.lineJoin = "round";
+      context.beginPath();
+      /* NOTE: canvas境界付近で描画したい軌跡が見切れてしまうのを防ぐために7px移動させている.
+      しかしこの7という数字は線幅に依存するため今後修正が必要. */
+      context.moveTo(projectedTrack[0][0] + 7, projectedTrack[0][1] + 7);
+
+      for (let i = 1; i < projectedTrack.length; i++) {
+        context.lineTo(projectedTrack[i][0] + 7, projectedTrack[i][1] + 7);
+      }
+
+      context.stroke();
+    }
+  }, [context]);
+
+  return (
+    <div>
+      <canvas id="canvas" style={styles.canvas} />
+      <div style={styles.text}>
+        <h1>TOKYO</h1>
+        <p>
+          ALTITUDE: 3.4 m<br />
+          DISTANCE: 7.44 km
+          <br />
+          2021.08.08
+          <br />
+        </p>
+        <p>FINISH &gt;</p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/result/Result.js
+++ b/src/components/result/Result.js
@@ -21,9 +21,7 @@ const styles = {
 };
 
 export const Result = () => {
-  // contextを状態として持つ
-  const [context, setContext] = useState(null);
-  // 画像読み込み完了トリガー
+  const [context, setContext] = useState();
 
   useEffect(() => {
     const canvas = document.getElementById("canvas");

--- a/src/lib/ProjectMercator.js
+++ b/src/lib/ProjectMercator.js
@@ -1,4 +1,4 @@
-export default function ProjectMercator(data) {
+export default function ProjectMercator(data, width) {
   if (data !== []) {
     const projectedData = [];
     let lng_min = data[0][0];
@@ -24,6 +24,8 @@ export default function ProjectMercator(data) {
       }
 
       lamda = (lng_min + lng_max) / 2;
+      const boxWidth = ((lng_max - lng_min) * Math.PI) / 180;
+      const scale = boxWidth !== 0 ? width / boxWidth : 1; //分母が0 の場合のエラーハンドリング
 
       /* 開始点の座標 */
       const x = (Math.PI * (lng_min - lamda)) / 180;
@@ -34,7 +36,7 @@ export default function ProjectMercator(data) {
       for (let i = 0; i < data.length; i++) {
         pos_x = (Math.PI * (data[i][0] - lamda)) / 180 - x; //各座標から開始点を引いて図形を原点から描画する
         pos_y = Math.log(Math.tan(Math.PI * (0.25 + data[i][1] / 360))) - y;
-        projectedData.push([pos_x, pos_y]);
+        projectedData.push([pos_x * scale, pos_y * scale]);
       }
       /* scale: x: x / (lng_max-lng_min) * scalor, x: y / (lat_max-lat_min) * scalor */
       return projectedData;

--- a/src/lib/ProjectMercator.js
+++ b/src/lib/ProjectMercator.js
@@ -29,13 +29,13 @@ export default function ProjectMercator(data, width) {
 
       /* 開始点の座標 */
       const x = (Math.PI * (lng_min - lamda)) / 180;
-      const y = Math.log(Math.tan(Math.PI * (0.25 + lat_min / 360)));
+      const y = Math.log(Math.tan(Math.PI * (0.25 + lat_max / 360)));
 
       let pos_x, pos_y;
 
       for (let i = 0; i < data.length; i++) {
         pos_x = (Math.PI * (data[i][0] - lamda)) / 180 - x; //各座標から開始点を引いて図形を原点から描画する
-        pos_y = Math.log(Math.tan(Math.PI * (0.25 + data[i][1] / 360))) - y;
+        pos_y = y - Math.log(Math.tan(Math.PI * (0.25 + data[i][1] / 360))); //NOTE: canvasのy軸は下向きが正.
         projectedData.push([pos_x * scale, pos_y * scale]);
       }
       /* scale: x: x / (lng_max-lng_min) * scalor, x: y / (lat_max-lat_min) * scalor */

--- a/src/lib/ProjectMercator.js
+++ b/src/lib/ProjectMercator.js
@@ -1,0 +1,47 @@
+export default function ProjectMercator(data) {
+  if (data !== []) {
+    const projectedData = [];
+    let lng_min = data[0][0];
+    let lng_max = data[0][0];
+    let lat_min = data[0][1];
+    let lat_max = data[0][1];
+    let lamda;
+    try {
+      /*最大, 最小値およびlamdaの算出*/
+      for (let i = 1; i < data.length; i++) {
+        if (data[i][0] > lng_max) {
+          lng_max = data[i][0];
+        }
+        if (data[i][0] < lng_min) {
+          lng_min = data[i][0];
+        }
+        if (data[i][1] > lat_max) {
+          lat_max = data[i][1];
+        }
+        if (data[i][1] < lat_min) {
+          lat_min = data[i][1];
+        }
+      }
+
+      lamda = (lng_min + lng_max) / 2;
+
+      /* 開始点の座標 */
+      const x = (Math.PI * (lng_min - lamda)) / 180;
+      const y = Math.log(Math.tan(Math.PI * (0.25 + lat_min / 360)));
+
+      let pos_x, pos_y;
+
+      for (let i = 0; i < data.length; i++) {
+        pos_x = (Math.PI * (data[i][0] - lamda)) / 180 - x; //各座標から開始点を引いて図形を原点から描画する
+        pos_y = Math.log(Math.tan(Math.PI * (0.25 + data[i][1] / 360))) - y;
+        projectedData.push([pos_x, pos_y]);
+      }
+      /* scale: x: x / (lng_max-lng_min) * scalor, x: y / (lat_max-lat_min) * scalor */
+      return projectedData;
+    } catch (e) {
+      console.log(e);
+    }
+  } else {
+    console.log("data is empty");
+  }
+}


### PR DESCRIPTION
#95  

### WHAT
- メルカトル法による投影を行う関数の作成

preview( 注：テストデータとして用いているjsonファイル, およびこのコンポーネントを表示するための記述はpushしていないので, vercelからこの画面をpreviewすることはできない )
![image](https://user-images.githubusercontent.com/47634358/128637286-21119b98-3cd3-4e10-8309-13767f9e2ae3.png)

### 今回のコミットでできること
- [[lng, lat], [lng, lat], ...]の形をした二次元配列を渡すとメルカトル法によって平面上に投影される
- 固定されたテキストでタイポグラフィが確認できる

### まだできないこと
- 移動距離や走った日時を軌跡に対応して動的に変化させること