### PR TITLE
エンコード時のエラーの原因同定

### DIFF
--- a/src/lib/EncodeTrack.js
+++ b/src/lib/EncodeTrack.js
@@ -1,6 +1,6 @@
 export default function EncodeTrack(data) {
   if (data !== []) {
-    let encoded_track = "";
+    let encoded_track = ""; //NOTE: 空文字を代入しておかないとundefinedという文字列が生じる(hatake511522/front_sandbox/#96)
     for (let i = 0; i < data.length - 1; i++) {
       if (data[i]) {
         encoded_track += data[i] + ":";

--- a/src/lib/EncodeTrack.js
+++ b/src/lib/EncodeTrack.js
@@ -8,6 +8,7 @@ export default function EncodeTrack(data) {
     }
     encoded_track += data[data.length - 1];
     // lng,lat:lng,lat...の形式に変換
+    alert(encoded_track);
     return encoded_track;
   } else {
     console.log("error happend while encoding track");

--- a/src/lib/EncodeTrack.js
+++ b/src/lib/EncodeTrack.js
@@ -8,7 +8,6 @@ export default function EncodeTrack(data) {
     }
     encoded_track += data[data.length - 1];
     // lng,lat:lng,lat...の形式に変換
-    alert(encoded_track);
     return encoded_track;
   } else {
     console.log("error happend while encoding track");

--- a/src/lib/EncodeTrack.js
+++ b/src/lib/EncodeTrack.js
@@ -1,7 +1,6 @@
 export default function EncodeTrack(data) {
   if (data !== []) {
-    alert(data);
-    let encoded_track;
+    let encoded_track = "";
     for (let i = 0; i < data.length - 1; i++) {
       if (data[i]) {
         encoded_track += data[i] + ":";
@@ -9,6 +8,7 @@ export default function EncodeTrack(data) {
     }
     encoded_track += data[data.length - 1];
     // lng,lat:lng,lat...の形式に変換
+    alert(encoded_track);
     return encoded_track;
   } else {
     console.log("error happend while encoding track");

--- a/src/lib/EncodeTrack.js
+++ b/src/lib/EncodeTrack.js
@@ -1,5 +1,6 @@
 export default function EncodeTrack(data) {
   if (data !== []) {
+    alert(data);
     let encoded_track;
     for (let i = 0; i < data.length - 1; i++) {
       if (data[i]) {
@@ -8,7 +9,6 @@ export default function EncodeTrack(data) {
     }
     encoded_track += data[data.length - 1];
     // lng,lat:lng,lat...の形式に変換
-    alert(encoded_track);
     return encoded_track;
   } else {
     console.log("error happend while encoding track");


### PR DESCRIPTION
#91 が未だに解決されていないのでその原因の調査. 
### 起こっていること
現状エンコードされたデータの先頭に"undefined"が含まれている.
```
{"id":55,"data":"undefined140.329698,38.2229531:140.3294449,38.222848: ...
```
このためデコード後```undefined140.329698``` の部分が読み込まれず, 軌跡の開始点が ``` NaN, 38.2229531 ``` となってしまう.

### 試したこと
- EncodeTrack内でのencode完了時にalert出力. undefinedを含む文字列がどのタイミングで生成されているかについての調査. → EncodeTrackの時点でundefinedが含まれることを確認.
- エンコード前のデータが正常かどうかの検証
→ エンコード前のデータにはundefinedは含まれていなかった.

### 結果
原因は, encoded_trackがundefinedだったこと. ここに文字列を結合していくとundefinedから始まる文字列になってしまう.
```
export default function EncodeTrack(data) {
  if (data !== []) {
    let encoded_track; //ここにエラー原因：encoded_track = undefined 
　for (let i = 0; i < data.length - 1; i++) {
      if (data[i]) {
        encoded_track += data[i] + ":"; //"undefined" + data[0] + ":" + data[1] + ":" + ...
      }
    }
```