### PR TITLE
ヒュべニの定理を用いた移動距離計算の高精度化

### DIFF
--- a/src/lib/CalcDistance.js
+++ b/src/lib/CalcDistance.js
@@ -15,12 +15,4 @@ export default function CalcDistance(pos_prev, pos_current) {
   const M = (Rx * (1 - E ** 2)) / W ** 3;
 
   return Math.sqrt((dy * M) ** 2 + (dx * N * Math.cos(p)) ** 2);
-  //   6371 *
-  //   Math.acos(
-  //     Math.cos((lat_c / 180) * pi) *
-  //       Math.cos(((lng_p - lng_c) / 180) * pi) *
-  //       Math.cos((lat_p / 180) * pi) +
-  //       Math.sin((lat_c / 180) * pi) * Math.sin((lat_p / 180) * pi)
-  //   ) *
-  //   1000
 }

--- a/src/lib/CalcDistance.js
+++ b/src/lib/CalcDistance.js
@@ -1,19 +1,26 @@
 export default function CalcDistance(pos_prev, pos_current) {
   const pi = Math.PI;
-  const lng_p = pos_prev.coords.longitude;
-  const lat_p = pos_prev.coords.latitude;
-  const lng_c = pos_current.coords.longitude;
-  const lat_c = pos_current.coords.latitude;
+  const lng_p = (pos_prev.coords.longitude / 180) * pi;
+  const lat_p = (pos_prev.coords.latitude / 180) * pi;
+  const lng_c = (pos_current.coords.longitude / 180) * pi;
+  const lat_c = (pos_current.coords.latitude / 180) * pi;
 
-  /*地球を半径6371kmの球体と仮定. 距離[m]=6371[km]*(２地点のなす角[rad])*1000 */
-  return (
-    6371 *
-    Math.acos(
-      Math.cos((lat_c / 180) * pi) *
-        Math.cos(((lng_p - lng_c) / 180) * pi) *
-        Math.cos((lat_p / 180) * pi) +
-        Math.sin((lat_c / 180) * pi) * Math.sin((lat_p / 180) * pi)
-    ) *
-    1000
-  );
+  const dx = lng_c - lng_p;
+  const dy = lat_c - lat_p;
+  const p = (lat_c + lat_p) / 2;
+  const Rx = 6378137; //WGS84に基づく長半径
+  const E = 0.08181919; //離心率
+  const W = Math.sqrt(1 - E ** 2 * Math.sin(p) ** 2);
+  const N = Rx / W;
+  const M = (Rx * (1 - E ** 2)) / W ** 3;
+
+  return Math.sqrt((dy * M) ** 2 + (dx * N * Math.cos(p)) ** 2);
+  //   6371 *
+  //   Math.acos(
+  //     Math.cos((lat_c / 180) * pi) *
+  //       Math.cos(((lng_p - lng_c) / 180) * pi) *
+  //       Math.cos((lat_p / 180) * pi) +
+  //       Math.sin((lat_c / 180) * pi) * Math.sin((lat_p / 180) * pi)
+  //   ) *
+  //   1000
 }


### PR DESCRIPTION
以前は移動距離の計算に、地球を球と仮定した上で、地球の半径のみを用いて計算を行なっていたため精度が低かった。
普通移動距離計算にはヒュべニの公式を使うらしい。
https://www.trail-note.net/tech/calc_distance/