### PR TITLE
ランニング中のマップ要素の操作を無効化

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -123,3 +123,7 @@ body {
     stroke-dashoffset: 0;
   }
 }
+
+.disablePointerEvents {
+  pointer-events: none;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -30,6 +30,7 @@ export const App = () => {
   const [animationOverlap, setAnimationOverlap] = useState();
   const [isLoggedIn, setIsLoggedIn] = useState();
   const [appState, setAppState] = useState("beginApp");
+  const [controlPointer, setControlPointer] = useState("");
   const [currentPos, setCurrentPos] = useState([{ lng: 0, lat: 0 }]);
   const [posHistory, setPosHistory] = useState([]);
 
@@ -53,8 +54,10 @@ export const App = () => {
   useEffect(() => {
     if (appState === "beginApp") {
       setAnimationOverlap("inset");
+      setControlPointer("");
     } else if (appState === "running") {
       setAnimationOverlap("scale-and-stop");
+      setControlPointer("disablePointerEvents");
     } else if (appState === "finishRunning") {
       setAnimationOverlap("iris-out");
     }
@@ -69,7 +72,7 @@ export const App = () => {
   }, [currentUser.id]);
 
   return (
-    <div className={styles.root}>
+    <div style={styles.root}>
       {isLoggedIn ? (
         <div>
           <WrapContent
@@ -82,23 +85,25 @@ export const App = () => {
             setAppState={setAppState}
           />
           <div className={animationOverlap}>
-            <ModalWindow />
-            <Header currentPlace={currentPlace} />
-            <MapBox
-              currentUser={currentUser}
-              tracks={tracks}
-              currentPos={currentPos}
-              distance={distance}
-              appState={appState}
-              posHistory={posHistory}
-              setTracks={setTracks}
-              setDistance={setDistance}
-              setCurrentPos={setCurrentPos}
-              setPosHistory={setPosHistory}
-              setMap={setMap}
-              setAppState={setAppState}
-            />
-            <Menu currentUser={currentUser} map={map} tracks={tracks} />
+            <div className={controlPointer}>
+              <ModalWindow />
+              <Header currentPlace={currentPlace} />
+              <MapBox
+                currentUser={currentUser}
+                tracks={tracks}
+                currentPos={currentPos}
+                distance={distance}
+                appState={appState}
+                posHistory={posHistory}
+                setTracks={setTracks}
+                setDistance={setDistance}
+                setCurrentPos={setCurrentPos}
+                setPosHistory={setPosHistory}
+                setMap={setMap}
+                setAppState={setAppState}
+              />
+              <Menu currentUser={currentUser} map={map} tracks={tracks} />
+            </div>
           </div>
         </div>
       ) : (

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -72,11 +72,6 @@ export const MapBox = ({
             lat: position.coords.latitude,
           });
           addition.current.push(GetAddition(position));
-          console.log(addition.current);
-          map.current.flyTo({
-            center: [position.coords.longitude, position.coords.latitude],
-            zoom: 15,
-          });
         } else {
           if (isValidPosition(prevPos, position)) {
             setCurrentPos({
@@ -90,6 +85,11 @@ export const MapBox = ({
             prevPos = position;
           }
         }
+
+        map.current.flyTo({
+          center: [position.coords.longitude, position.coords.latitude],
+          zoom: 15,
+        });
       },
       () => {},
       { enableHighAccuracy: true }

--- a/src/components/map/MapBox.js
+++ b/src/components/map/MapBox.js
@@ -85,11 +85,6 @@ export const MapBox = ({
             prevPos = position;
           }
         }
-
-        map.current.flyTo({
-          center: [position.coords.longitude, position.coords.latitude],
-          zoom: 15,
-        });
       },
       () => {},
       { enableHighAccuracy: true }
@@ -186,6 +181,10 @@ export const MapBox = ({
   useEffect(() => {
     if (appState === "running") {
       setPosHistory([...posHistory, [currentPos.lng, currentPos.lat]]);
+      map.current.flyTo({
+        center: [currentPos.lng, currentPos.lat],
+        zoom: 15,
+      });
     }
   }, [currentPos]);
 


### PR DESCRIPTION
### WHY
- ランニング中には基本的に操作はしないから。
- iPhoneの場合、clip-pathを通して前面に表示させているオブジェクトがさわれず、その後ろにあるmapなどが触れる状態になっていた。下をさわれなくすることで上が触れるようにする。

### WHAT
- appStateがrunningになったら画面全体のpointer-eventを無効にする。
- マップの操作ができなくなる代わりに、円の中心が常に現在位置になるように、flyTo関数を現在位置が更新されるたび呼び出すように修正。